### PR TITLE
Expand AES artifact gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ venv/
 *.pt
 *.pth
 *.h5
+*.keras
+*.ckpt
 
 outputs/
 results/
+checkpoints/
+data/
+*.csv
+*.xlsx
+*.npy


### PR DESCRIPTION
Adds ignore rules for checkpoints, Keras artifacts, local data, generated arrays, and spreadsheet outputs.